### PR TITLE
Ethernet submodule working on fpga

### DIFF
--- a/software/embedded/iob-eth.c
+++ b/software/embedded/iob-eth.c
@@ -101,8 +101,8 @@ int eth_rcv_frame(char *data_rcv, unsigned int size, int timeout) {
   }
 
   if( IO_GET(base, ETH_CRC) != 0xc704dd7b) {
-    uart_puts("Bad CRC\n");
     IO_SET(base, ETH_RCVACK, 1);
+    uart_puts("Bad CRC\n");
     return ETH_NO_DATA;
   }
 

--- a/software/software.mk
+++ b/software/software.mk
@@ -10,5 +10,5 @@ HDR+=$(ETHERNET_SW_DIR)/*.h
 ifneq ($(SIM),)
 DEFINE+=$(define)ETH_RMAC_ADDR=0x0123456789ab
 else
-DEFINE+=$(define)ETH_RMAC_ADDR=0x$(shell ethtool -P $(RMAC_INTERFACE) | awk '{print $$3}' | sed "s/://g")
+DEFINE+=$(define)ETH_RMAC_ADDR=0x$(RMAC_ADDR)
 endif


### PR DESCRIPTION
RMAC is now defined from system.mk in iob-soc according to target fpga

Printing BAD CRC before setting ACK in ethernet takes too much time and caused module to loose next packet