### PR TITLE
Remove ISO C++ warning

### DIFF
--- a/software/embedded/iob-eth.c
+++ b/software/embedded/iob-eth.c
@@ -46,13 +46,11 @@ void eth_init(int base_address)
 
   //wait for PHY to produce rx clock 
   while(!((IO_GET(base, ETH_STATUS)>>3)&1));
-  char RX_clk_msg[30] = "Ethernet RX clock detected\n";
-  uart_puts(RX_clk_msg);
+  uart_puts((char *)"Ethernet RX clock detected\n");
 
   //wait for PLL to lock and produce tx clock 
   while(!((IO_GET(base, ETH_STATUS)>>15)&1));
-  char TX_pll_msg[25] = "Ethernet TX PLL locked\n";
-  uart_puts(TX_pll_msg);
+  uart_puts((char*)"Ethernet TX PLL locked\n");
 
   //set initial payload size to Ethernet minimum excluding FCS
   IO_SET(base, ETH_TX_NBYTES, 46);
@@ -64,12 +62,10 @@ void eth_init(int base_address)
 
   // read and check result
   if (IO_GET(base, ETH_DUMMY) != 0xDEADBEEF){
-    char init_fail_msg[25] = "Ethernet Init failed\n";
-    uart_puts(init_fail_msg);
+    uart_puts((char*)"Ethernet Init failed\n");
   }
   else{
-    char init_success_msg[30] = "Ethernet Core Initialized\n";
-    uart_puts(init_success_msg);
+    uart_puts((char*)"Ethernet Core Initialized\n");
   }
 }
 
@@ -97,8 +93,6 @@ void eth_send_frame(char *data, unsigned int size) {
 
 int eth_rcv_frame(char *data_rcv, unsigned int size, int timeout) {
   int i;
-  char bad_crc_msg[10] = "Bad CRC\n";
-
 
   // wait until data received
   while(!((IO_GET(base, ETH_STATUS)>>1)&1)) {
@@ -110,7 +104,7 @@ int eth_rcv_frame(char *data_rcv, unsigned int size, int timeout) {
 
   if( IO_GET(base, ETH_CRC) != 0xc704dd7b) {
     IO_SET(base, ETH_RCVACK, 1);
-    uart_puts(bad_crc_msg);
+    uart_puts((char*)"Bad CRC\n");
     return ETH_NO_DATA;
   }
 


### PR DESCRIPTION
Stop g++ from infering conversion from const string to char*