### PR TITLE
Byte buffer

### DIFF
--- a/hardware/include/iob_eth_swreg.vh
+++ b/hardware/include/iob_eth_swreg.vh
@@ -8,5 +8,5 @@
 `IOB_SWREG_W(ETH_TX_NBYTES, 11, 46) //Number of bytes for outcomming frames. 
 `IOB_SWREG_R(ETH_CRC, 32, 0) //CRC of last received frame.
 `IOB_SWREG_R(ETH_RCV_SIZE, 11, 0) //Number of bytes of last received frame.
-`IOB_SWMEM_W(ETH_DATA_WR, 32, 9) //TX Buffer.
+`IOB_SWMEM_W(ETH_DATA_WR, 8, 11) //TX Buffer.
 `IOB_SWMEM_R(ETH_DATA_RD, 32, 9) //RX Buffer.

--- a/hardware/include/iob_eth_swreg.vh
+++ b/hardware/include/iob_eth_swreg.vh
@@ -9,4 +9,4 @@
 `IOB_SWREG_R(ETH_CRC, 32, 0) //CRC of last received frame.
 `IOB_SWREG_R(ETH_RCV_SIZE, 11, 0) //Number of bytes of last received frame.
 `IOB_SWMEM_W(ETH_DATA_WR, 8, 11) //TX Buffer.
-`IOB_SWMEM_R(ETH_DATA_RD, 32, 9) //RX Buffer.
+`IOB_SWMEM_R(ETH_DATA_RD, 8, 11) //RX Buffer.

--- a/hardware/src/iob_eth.v
+++ b/hardware/src/iob_eth.v
@@ -55,8 +55,8 @@ module iob_eth
     `IOB_WIRE(tx_ready_int, 1)
     `IOB_WIRE(rx_data_rcvd_int, 1)
 
-    `IOB_WIRE(tx_rd_addr, 9)
-    `IOB_WIRE(tx_rd_data, 32)
+    `IOB_WIRE(tx_rd_addr, 11)
+    `IOB_WIRE(tx_rd_data, 8)
 
     `IOB_WIRE(rx_wr_addr, 11)
     `IOB_WIRE(rx_wr_data, 8)
@@ -125,7 +125,7 @@ module iob_eth
    //
 
    iob_ram_t2p #(
-                       .DATA_W(32),
+                       .DATA_W(8),
                        .ADDR_W(`ETH_DATA_WR_ADDR_W)
                        )
    tx_buffer
@@ -182,20 +182,6 @@ module iob_eth
    // TRANSMITTER
    //
 
-   // Transform 32 bit data from tx_buffer to 8 bit data for tx input
-   reg [1:0] delayed_tx_sel;
-   wire [10:0] tx_out_addr;
-   
-   always @(posedge TX_CLK,posedge rst_int)
-     if(rst_int)
-       delayed_tx_sel <= 0;
-     else
-       delayed_tx_sel <= tx_out_addr[1:0];
-
-   assign tx_rd_addr = tx_out_addr[10:2];
-   wire [7:0] tx_in_data = delayed_tx_sel[1] ? (delayed_tx_sel[0] ? tx_rd_data[8*3 +: 8] : tx_rd_data[8*2 +: 8]):
-                                               (delayed_tx_sel[0] ? tx_rd_data[8*1 +: 8] : tx_rd_data[8*0 +: 8]);
-
    iob_eth_tx
      tx (
          // cpu side
@@ -205,8 +191,8 @@ module iob_eth
 
          // mii side
          .send    (send),
-         .addr    (tx_out_addr),
-         .data    (tx_in_data),
+         .addr    (tx_rd_addr),
+         .data    (tx_rd_data),
          .TX_CLK  (TX_CLK),
          .TX_EN   (TX_EN),
          .TX_DATA (TX_DATA)

--- a/hardware/src/iob_eth.v
+++ b/hardware/src/iob_eth.v
@@ -143,33 +143,17 @@ module iob_eth
       .r_data(tx_rd_data)
    );
 
-   // Transform 8 bit rx data to 32 bit data to be stored in rx_buffer
-   reg [8:0] stored_rx_addr;
-   reg [31:0] stored_rx_data; 
-   reg stored_rx_wr;
-
-   always @(posedge RX_CLK,posedge rst)
-   if(rst) begin
-     stored_rx_addr <= 0;
-     stored_rx_data <= 0;
-     stored_rx_wr <= 1'b0;
-   end else if(rx_wr) begin
-     stored_rx_addr <= rx_wr_addr[10:2];
-     stored_rx_data[8 * rx_wr_addr[1:0] +: 8] <= rx_wr_data;
-     stored_rx_wr <= 1'b1;
-   end
-
    iob_ram_t2p #(
-                       .DATA_W(32),
+                       .DATA_W(8),
                        .ADDR_W(`ETH_DATA_RD_ADDR_W)
                        )
    rx_buffer
    (
      // Front-End (written by core)
      .w_clk(RX_CLK),
-     .w_addr(stored_rx_addr),
-     .w_en(stored_rx_wr),
-     .w_data(stored_rx_data),
+     .w_addr(rx_wr_addr),
+     .w_en(rx_wr),
+     .w_data(rx_wr_data),
 
      // Back-End (read by host)
      .r_clk(clk),

--- a/software/iob-eth.c
+++ b/software/iob-eth.c
@@ -164,14 +164,6 @@ void eth_set_tx_payload_size(unsigned int size) {
     ETH_SET_TX_NBYTES(size + TEMPLATE_LEN);
 }
 
-char eth_get_data(int i) {
-  int data = ETH_GET_DATA_RD(i / 4);
-
-  data >>= (8 * (i % 4));
-
-  return ((char) data & 0xff);
-}
-
 void eth_set_tx_buffer(char* buffer,int size){
   for(int i=0; i<size; i++){
       ETH_SET_DATA_WR(TEMPLATE_LEN + i, buffer[i]);
@@ -184,7 +176,7 @@ void eth_get_rx_buffer(char* buffer,int size){
   int rx_data_offset = PAYLOAD_PTR - MAC_DEST_PTR;
 
   for(int i = 0; i < size; i++){
-    buffer[i] = eth_get_data(i+rx_data_offset);
+    buffer[i] = ETH_GET_DATA_RD(i+rx_data_offset);
   }
 }
 

--- a/software/iob-eth.c
+++ b/software/iob-eth.c
@@ -173,13 +173,8 @@ char eth_get_data(int i) {
 }
 
 void eth_set_tx_buffer(char* buffer,int size){
-  int i = 0, j = 0;
-  int i_val = 0;
-  int eth_data_payload_addr = TEMPLATE_LEN/4;
-
-  for( i=0, j=0; i<size; j++){
-      i += get_int(buffer + i, &i_val);
-      ETH_SET_DATA_WR(eth_data_payload_addr + j, i_val);
+  for(int i=0; i<size; i++){
+      ETH_SET_DATA_WR(TEMPLATE_LEN + i, buffer[i]);
   }
 }
 
@@ -194,12 +189,8 @@ void eth_get_rx_buffer(char* buffer,int size){
 }
 
 void eth_init_frame(void) {
-  int i = 0, j = 0;
-  int i_val = 0;
-  
-  for (i = 0, j = 0; i < TEMPLATE_LEN; j++) {
-    i += get_int(TEMPLATE + i, &i_val);
-    ETH_SET_DATA_WR(j, i_val);
+  for (int i = 0; i < TEMPLATE_LEN; i++) {
+    ETH_SET_DATA_WR(i, TEMPLATE[i]);
   }
 }
 

--- a/software/iob-eth.h
+++ b/software/iob-eth.h
@@ -35,8 +35,6 @@ int eth_get_status_field(char field);
 
 void eth_set_tx_payload_size(unsigned int size);
 
-char eth_get_data(int i);
-
 void eth_set_tx_buffer(char* buffer,int size);
 
 void eth_get_rx_buffer(char* buffer,int size);

--- a/software/pc-emul/iob_eth_swreg_pc_emul.c
+++ b/software/pc-emul/iob_eth_swreg_pc_emul.c
@@ -135,9 +135,9 @@ void ETH_SET_DATA_WR(uint16_t addr, uint8_t value) {
     return;
 }
 
-uint32_t ETH_GET_DATA_RD(uint16_t addr) {
+uint8_t ETH_GET_DATA_RD(uint16_t addr) {
     // read data from rcv buffer
-    return *( ((int*)rcv_buffer) + addr);
+    return rcv_buffer[addr];
 }
 
 

--- a/software/pc-emul/iob_eth_swreg_pc_emul.c
+++ b/software/pc-emul/iob_eth_swreg_pc_emul.c
@@ -129,10 +129,9 @@ void ETH_SET_TX_NBYTES(uint16_t value) {
  * or
  * read data from received frame
  */
-void ETH_SET_DATA_WR(uint16_t addr, uint32_t value) {
+void ETH_SET_DATA_WR(uint16_t addr, uint8_t value) {
     // write data to send buffer
-    int *send_buffer_int = (int*) (send_buffer);
-    send_buffer_int[addr] = value;
+    send_buffer[addr] = value;
     return;
 }
 


### PR DESCRIPTION
- Use Byte DATA_W for TX and RX Buffers
- Update software drivers accordingly
- Simplify iob_eth.v core logic
- Still runs correctly in fpga