### PR TITLE
fix(pc-emul): Add target to clean local socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,14 @@ raw socket capabilities.
   ```
   sudo ethtool -s $RMAC_INTERFACE speed 100 duplex full autoneg off
   ```
+### `Failed to bind socket` on PC-Emul
+- The pc-emul drivers create a local socket file in `/tmp/tmpLocalSocket`, but
+  this socket is never closed by the drivers. This behaviour mirrors the
+  embedded version, where there is no equivalent operation to close sockets.
+- To remove the local socket file add the following target to `pc-emul/Makefile` clean target:
+```Make
+# pc-emul/Makefile clean target
+clean:
+    (...)
+    make clean-eth-socket
+```

--- a/software/pc-emul/pc-emul.mk
+++ b/software/pc-emul/pc-emul.mk
@@ -4,3 +4,6 @@ include $(ETHERNET_DIR)/software/software.mk
 # add pc-emul sources
 SRC+=$(ETHERNET_SW_DIR)/pc-emul/iob_eth_swreg_pc_emul.c
 
+# clean socket file
+clean-eth-socket:
+	@rm -rf /tmp/tmpLocalSocket


### PR DESCRIPTION
- PC emul opens local socket file in `/tmp/tmpLocalSocket`, but socket
  is never properly closed by test firmware (to keep parity with
  embedded version, where there is no equivalent operation to close
  sockets)
- The developers using ethernet for pc-emulation should add:
```Make
make clean-eth-socket
```
to pc-emul clean target
- Add instructions to README