### PR TITLE
Add PHY_RST_CNT parameter in verilog; Add modifiable MAC address in drivers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,15 @@ The main steps to integrate iob-eth core into an iob-soc system:
     include $(ETHERNET_DIR)/software/embedded/embedded.mk
     ```
 3. Define `SIM` for simulation:
-    1. Add `SIM` variable in `hardware/simulation/simulation.mk` before
-       including `hardware/hardware.mk`:
-    ```Make
-    SIM=1
-    DEFINE+=$(defmacro)SIM=$(SIM)
-    ```
-    2. Add `SIM` to firmware in case of simulation in
+    This allows using `#ifdef SIM` in the firmware.
+    1. Add `SIM` to firmware in case of simulation in
        `software/firmware/Makefile`:
     ```Make
     ifeq ($(SIM),1)
     DEFINE+=$(defmacro)SIM=$(SIM)
     endif
     ```
-    3. Set `SIM` variable in `Makefile` when making embedded sw for simulation:
+    2. Set `SIM` variable in `Makefile` when making embedded sw for simulation:
     ```Make
     # Original make call
         sim-build:
@@ -132,8 +127,8 @@ The main steps to integrate iob-eth core into an iob-soc system:
     - this should be the one connected to the FPGA BOARD
 - set `RMAC_INTERFACE=enBBBB` in your `~/.bashrc`
 ### System simulation takes a long time to initialize ethernet:
-- ethernet simulation requires `DEFINE+=$(defmacro)SIM` so that internal reset takes less time 
-  - check for `SIM` in `ETHERNET/hardware/src/iob_eth.v` for more details
+- ethernet simulation has an internal reset counter, configurable by a verilog parameter
+  - check for `PHY_RST_CNT` in `ETHERNET/hardware/src/iob_eth.v` for more details
 ### No permissions to open raw sockets
 - Running raw sockets requires elevated privileges. This is solved by 
 configuring a dedicated python3 virtual environment where the interpreter has 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ The main steps to integrate iob-eth core into an iob-soc system:
     ```
     PERIPHERALS ?= UART <...> ETHERNET
     ```
+        1. MAC address and simulation mode can be configured via instance parameters.
+        ```
+        PERIPHERALS ?= UART <...> ETHERNET[32,\`iob_eth_swreg_ADDR_W,\`ETH_MAC_ADDR,$(if $(SIM),1,0)]
+        ```
+        In this example, arguments 1 and 2 are the default values, argument 3 sets the MAC address using a macro included in ETHERNET, argument 4 sets this instance into simulation mode if it evaluates to '1' (whenever the SIM variable is defined).
     3. Add path to iob-eth submodule in `config.mk` file:
     ```
     ETHERNET_DIR=$(ROOT_DIR)/submodules/ETHERNET

--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ The main steps to integrate iob-eth core into an iob-soc system:
     ```
     PERIPHERALS ?= UART <...> ETHERNET
     ```
-        1. MAC address and simulation mode can be configured via instance parameters.
-        ```
-        PERIPHERALS ?= UART <...> ETHERNET[32,\`iob_eth_swreg_ADDR_W,\`ETH_MAC_ADDR,$(if $(SIM),1,0)]
-        ```
-        In this example, arguments 1 and 2 are the default values, argument 3 sets the MAC address using a macro included in ETHERNET, argument 4 sets this instance into simulation mode if it evaluates to '1' (whenever the SIM variable is defined).
     3. Add path to iob-eth submodule in `config.mk` file:
     ```
     ETHERNET_DIR=$(ROOT_DIR)/submodules/ETHERNET

--- a/hardware/src/iob_eth.v
+++ b/hardware/src/iob_eth.v
@@ -13,7 +13,7 @@ module iob_eth
     parameter DATA_W = 32, //PARAM CPU data width
     parameter ADDR_W = `iob_eth_swreg_ADDR_W, //MACRO CPU address section width
     parameter ETH_MAC_ADDR = `ETH_MAC_ADDR, //Instance MAC address
-    parameter SIM = 0 //Set if instance is to be built for simulation
+    parameter PHY_RST_CNT = 20'hFFFFF //Set reset counter value
     )
     (
     // CPU interface
@@ -295,7 +295,7 @@ module iob_eth
         phy_rst_cnt <= 0;
         ETH_PHY_RESETN <= 0;
      end else 
-       if (phy_rst_cnt != ((SIM==0) ? 20'hFFFFF : 20'h000FF)) // Faster for simulation
+       if (phy_rst_cnt != PHY_RST_CNT)
          phy_rst_cnt <= phy_rst_cnt+1'b1;
        else
          ETH_PHY_RESETN <= 1;

--- a/hardware/src/iob_eth.v
+++ b/hardware/src/iob_eth.v
@@ -12,7 +12,8 @@ module iob_eth
     # (
     parameter DATA_W = 32, //PARAM CPU data width
     parameter ADDR_W = `iob_eth_swreg_ADDR_W, //MACRO CPU address section width
-    parameter ETH_MAC_ADDR = `ETH_MAC_ADDR
+    parameter ETH_MAC_ADDR = `ETH_MAC_ADDR, //Instance MAC address
+    parameter SIM = 0 //Set if instance is to be built for simulation
     )
     (
     // CPU interface
@@ -294,11 +295,7 @@ module iob_eth
         phy_rst_cnt <= 0;
         ETH_PHY_RESETN <= 0;
      end else 
-`ifdef SIM // Faster for simulation
-       if (phy_rst_cnt != 20'h000FF)
-`else
-       if (phy_rst_cnt != 20'hFFFFF)
-`endif
+       if (phy_rst_cnt != ((SIM==0) ? 20'hFFFFF : 20'h000FF)) // Faster for simulation
          phy_rst_cnt <= phy_rst_cnt+1'b1;
        else
          ETH_PHY_RESETN <= 1;

--- a/software/iob-eth.c
+++ b/software/iob-eth.c
@@ -69,8 +69,15 @@ static void print_buffer(char *buffer, int size){
 /*******************************************/
 
 void eth_init(int base_address) {
+#ifdef LOOPBACK
+	eth_init_mac(base_address, ETH_MAC_ADDR, ETH_MAC_ADDR);
+#else
+	eth_init_mac(base_address, ETH_MAC_ADDR, ETH_RMAC_ADDR);
+#endif
+}
+
+void eth_init_mac(int base_address, uint64_t mac_addr, uint64_t dest_mac_addr) {
   int i,ret;
-  uint64_t mac_addr;
 
   // set base address
   IOB_ETH_INIT_BASEADDR(base_address);
@@ -83,18 +90,12 @@ void eth_init(int base_address) {
   TEMPLATE[SDF_PTR] = ETH_SFD;
 
   // dest mac address
-#ifdef LOOPBACK
-  mac_addr = ETH_MAC_ADDR;
-#else
-  mac_addr = ETH_RMAC_ADDR;
-#endif
   for (i=0; i < MAC_ADDR_LEN; i++) {
-    TEMPLATE[MAC_DEST_PTR+i] = mac_addr >> 40;
-    mac_addr = mac_addr << 8;
+    TEMPLATE[MAC_DEST_PTR+i] = dest_mac_addr >> 40;
+    dest_mac_addr = dest_mac_addr << 8;
   }
 
   // source mac address
-  mac_addr = ETH_MAC_ADDR;
   for (i=0; i < MAC_ADDR_LEN; i++) {
     TEMPLATE[MAC_SRC_PTR+i] = mac_addr >> 40;
     mac_addr = mac_addr << 8;

--- a/software/iob-eth.h
+++ b/software/iob-eth.h
@@ -31,7 +31,9 @@
 #define ETH_DEBUG_PRINT 1
 
 // driver functions
-void eth_init(int base);
+void eth_init(int base_address);
+
+void eth_init_mac(int base_address, uint64_t mac_addr, uint64_t dest_mac_addr);
 
 int eth_get_status_field(char field);
 

--- a/software/software.mk
+++ b/software/software.mk
@@ -11,11 +11,7 @@ HDR+=iob_eth_swreg.h eth_frame_struct.h
 SRC+=$(ETHERNET_SW_DIR)/iob-eth.c
 
 #define ETH_RMAC_ADDR
-ifneq ($(SIM),)
-DEFINE+=$(defmacro)ETH_RMAC_ADDR=0x001200feaa00
-else
 DEFINE+=$(defmacro)ETH_RMAC_ADDR=0x$(RMAC_ADDR)
-endif
 
 #define ETH_DEBUG_PRINT
 ifeq ($(ETH_DEBUG_PRINT),1)


### PR DESCRIPTION
- Add `SIM` parameter in the ethernet verilog module to remove dependecy on fixed macro. This allows having different values for each instance, therefore allowing some instances to run in "simulation mode" (with optimizations for simulation), while others don´t.
- Update drivers to allow configuring the MAC address through arguments (instead of relying on a fixed define). This allows initializing multiple instances with different MAC addresses.