### PR TITLE
Move buffer memories outside ethernet core

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ The main steps to integrate iob-eth core into an iob-soc system:
             make fw-build SIM=1
             make -C $(SIM_DIR) build
     ```
-4. Update FPGA Board files:
+4. Add external memories outside of system:
+    Alongside the system instantiation, include the verilog header:
+    `iob_eth_buffer_inst.vh`. Note that the verilog header also requires
+    `iob_eth.vh`.
+    For iob-soc type systems, include the headers in `system_top_core.vh`.
+5. Update FPGA Board files:
     1. Check 
     `ETHERNET/hardware/fpga/vivado/AES-KU040-DG-B/top_system_eth_template.vh`
     for details on the ports and logic to add to the top level module.
@@ -76,14 +81,14 @@ The main steps to integrate iob-eth core into an iob-soc system:
     example of constraints required for the ethernet core.
     Note: these files are for the `AES-KU040-DB-G` board. For other devices you
     need to adapt the examples.
-5. Create python scripts to communicate with the FPGA Board.
+6. Create python scripts to communicate with the FPGA Board.
     1. Check `ETHERNET/software/example_python.py` and
        `ETHERNET/software/python/` for examples.
     2. Check `ETHERNET/Makefile` for usage targets.
-6. Update embedded firmware to use the iob-eth core
+7. Update embedded firmware to use the iob-eth core
     1. Check `ETHERNET/software/example_firmware.c` for an example program with
     ethernet communication.
-7. Use wrapper script to run console and python script in parallel
+8. Use wrapper script to run console and python script in parallel
     1. Copy the wrapper script to the console location:
     ```
     cp submodules/ETHERNET/software/console/eth_console software/console/
@@ -109,7 +114,7 @@ The main steps to integrate iob-eth core into an iob-soc system:
     ```Make
 	scp $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD)/ethernet.log .
     ```
-8. Run in PC-Emul, Simulation or FPGA:
+9. Run in PC-Emul, Simulation or FPGA:
     1. Use same targets as default `iob-soc`
     2. Console output is printed to terminal, ethernet script output is printed
        to `ethernet.log`.

--- a/hardware/fpga/vivado/AES-KU040-DB-G/top_system_eth_template.vh
+++ b/hardware/fpga/vivado/AES-KU040-DB-G/top_system_eth_template.vh
@@ -69,6 +69,9 @@ module top_system(
 
     assign locked = 1'b1; 
 
+    // Ethernet Buffer External Memories
+    `include "iob_eth_buffer_inst.vh"
+
     //
     // TOP SYSTEM LOGIC
     //
@@ -91,6 +94,7 @@ module top_system(
             //
 
             //ETHERNET
+            `include "iob_eth_buffer_portmap.vh"
             //PHY
             .ETH_PHY_RESETN(ENET_RESETN),
 

--- a/hardware/fpga/vivado/AES-KU040-DB-G/top_system_eth_template.vh
+++ b/hardware/fpga/vivado/AES-KU040-DB-G/top_system_eth_template.vh
@@ -10,13 +10,18 @@
 // 3. System instance ports for ethernet interface
 //
 ////////////////////////////////////////////////////////////////////////////////
+
+//
+// 1. Include SWREG Defines (used by iob_eth_buffer_inst.vh)
+//
+`include "iob_eth_swreg_def.vh"
 module top_system(
 
         // other top_system ports
         // ....
 
         //
-        // 1. top_system module ports for ethernet interface
+        // 2. top_system module ports for ethernet interface
         //
         output ENET_RESETN,
         input  ENET_RX_CLK,
@@ -38,7 +43,7 @@ module top_system(
     );
 
     // 
-    // 2. Logic to contatenate data pins and ethernet clock
+    // 3. Logic to contatenate data pins and ethernet clock
     //
 
     //buffered eth clock
@@ -68,8 +73,13 @@ module top_system(
              );
 
     assign locked = 1'b1; 
+    
 
     // Ethernet Buffer External Memories
+    wire RX_CLK;
+    wire TX_CLK;
+    assign RX_CLK = ETH_CLK;
+    assign TX_CLK = ETH_CLK;
     `include "iob_eth_buffer_inst.vh"
 
     //
@@ -90,7 +100,7 @@ module top_system(
             // ...
             
             //
-            // 3. System instance ports for ethernet interface
+            // 4. System instance ports for ethernet interface
             //
 
             //ETHERNET

--- a/hardware/include/inst.vh
+++ b/hardware/include/inst.vh
@@ -9,6 +9,9 @@
       .clk      (clk),
       .rst      (reset),
 
+      // external memory macros
+      `include "iob_eth_buffer_portmap.vh"
+
       //cpu interface
       .valid(slaves_req[`valid(`ETHERNET)]),
       .address(slaves_req[`address(`ETHERNET, `iob_eth_swreg_ADDR_W+2)-2]),

--- a/hardware/include/inst_tb.vh
+++ b/hardware/include/inst_tb.vh
@@ -17,7 +17,7 @@
 
 iob_eth_tb_gen eth_tb(
       .clk      (clk),
-      .reset    (reset),
+      .reset    (rst),
 
       // This module acts like a loopback
       .RX_CLK(TX_CLK),

--- a/hardware/include/iob_eth_buffer_inst.vh
+++ b/hardware/include/iob_eth_buffer_inst.vh
@@ -1,0 +1,67 @@
+    // TX Front-End
+    wire                              iob_eth_tx_buffer_enA;
+    wire [32/8-1:0]                   iob_eth_tx_buffer_weA;
+    wire [`ETH_DATA_WR_ADDR_W-1:0]    iob_eth_tx_buffer_addrA;
+    wire [32-1:0]                     iob_eth_tx_buffer_dinA;
+
+    // TX Back-End
+    wire [`ETH_DATA_WR_ADDR_W-1:0]    iob_eth_tx_buffer_addrB;
+    wire [32-1:0]                      iob_eth_tx_buffer_doutB;
+
+    // RX Front-End
+    wire                              iob_eth_rx_buffer_enA;
+    wire [32/8-1:0]                   iob_eth_rx_buffer_weA;
+    wire [`ETH_DATA_RD_ADDR_W-1:0]    iob_eth_rx_buffer_addrA;
+    wire [32-1:0]                     iob_eth_rx_buffer_dinA;
+
+     // RX Back-End
+    wire                              iob_eth_rx_buffer_enB;
+    wire [`ETH_DATA_RD_ADDR_W-1:0]    iob_eth_rx_buffer_addrB;
+    wire [32-1:0]                      iob_eth_rx_buffer_doutB;
+
+   iob_ram_tdp_be #(
+                       .DATA_W(32),
+                       .ADDR_W(`ETH_DATA_WR_ADDR_W)
+                       )
+   tx_buffer
+   (
+    // Front-End (written by host)
+      .clkA(clk),
+      .enA(iob_eth_tx_buffer_enA),
+      .weA(iob_eth_tx_buffer_weA),
+      .addrA(iob_eth_tx_buffer_addrA),
+      .dinA(iob_eth_tx_buffer_dinA),
+      .doutA(),
+
+    // Back-End (read by core)
+      .clkB(TX_CLK),
+      .enB(1'b1),
+      .weB(4'b0),
+      .addrB(iob_eth_tx_buffer_addrB),
+      .dinB(32'b0),
+      .doutB(iob_eth_tx_buffer_doutB)
+   );
+
+   iob_ram_tdp_be #(
+                       .DATA_W(32),
+                       .ADDR_W(`ETH_DATA_RD_ADDR_W)
+                       )
+   rx_buffer
+   (
+     // Front-End (written by core)
+     .clkA(RX_CLK),
+
+     .enA(iob_eth_rx_buffer_enA),
+     .weA(iob_eth_rx_buffer_weA),
+     .addrA(iob_eth_rx_buffer_addrA),
+     .dinA(iob_eth_rx_buffer_dinA),
+     .doutA(),
+
+     // Back-End (read by host)
+     .clkB(clk),
+     .enB(iob_eth_rx_buffer_enB),
+     .weB(4'b0),
+     .addrB(iob_eth_rx_buffer_addrB),
+     .dinB(32'b0),
+     .doutB(iob_eth_rx_buffer_doutB)
+   );

--- a/hardware/include/iob_eth_buffer_inst.vh
+++ b/hardware/include/iob_eth_buffer_inst.vh
@@ -1,24 +1,3 @@
-    // TX Front-End
-    wire                              iob_eth_tx_buffer_enA;
-    wire [32/8-1:0]                   iob_eth_tx_buffer_weA;
-    wire [`ETH_DATA_WR_ADDR_W-1:0]    iob_eth_tx_buffer_addrA;
-    wire [32-1:0]                     iob_eth_tx_buffer_dinA;
-
-    // TX Back-End
-    wire [`ETH_DATA_WR_ADDR_W-1:0]    iob_eth_tx_buffer_addrB;
-    wire [32-1:0]                     iob_eth_tx_buffer_doutB;
-
-    // RX Front-End
-    wire                              iob_eth_rx_buffer_enA;
-    wire [32/8-1:0]                   iob_eth_rx_buffer_weA;
-    wire [`ETH_DATA_RD_ADDR_W-1:0]    iob_eth_rx_buffer_addrA;
-    wire [32-1:0]                     iob_eth_rx_buffer_dinA;
-
-     // RX Back-End
-    wire                              iob_eth_rx_buffer_enB;
-    wire [`ETH_DATA_RD_ADDR_W-1:0]    iob_eth_rx_buffer_addrB;
-    wire [32-1:0]                     iob_eth_rx_buffer_doutB;
-
    iob_ram_tdp_be #(
                        .DATA_W(32),
                        .ADDR_W(`ETH_DATA_WR_ADDR_W)

--- a/hardware/include/iob_eth_buffer_inst.vh
+++ b/hardware/include/iob_eth_buffer_inst.vh
@@ -6,7 +6,7 @@
 
     // TX Back-End
     wire [`ETH_DATA_WR_ADDR_W-1:0]    iob_eth_tx_buffer_addrB;
-    wire [32-1:0]                      iob_eth_tx_buffer_doutB;
+    wire [32-1:0]                     iob_eth_tx_buffer_doutB;
 
     // RX Front-End
     wire                              iob_eth_rx_buffer_enA;
@@ -17,7 +17,7 @@
      // RX Back-End
     wire                              iob_eth_rx_buffer_enB;
     wire [`ETH_DATA_RD_ADDR_W-1:0]    iob_eth_rx_buffer_addrB;
-    wire [32-1:0]                      iob_eth_rx_buffer_doutB;
+    wire [32-1:0]                     iob_eth_rx_buffer_doutB;
 
    iob_ram_tdp_be #(
                        .DATA_W(32),

--- a/hardware/include/iob_eth_buffer_port.vh
+++ b/hardware/include/iob_eth_buffer_port.vh
@@ -1,0 +1,20 @@
+    // TX Front-End
+    output                              iob_eth_tx_buffer_enA,
+    output [32/8-1:0]                   iob_eth_tx_buffer_weA,
+    output [`ETH_DATA_WR_ADDR_W-1:0]    iob_eth_tx_buffer_addrA,
+    output [32-1:0]                     iob_eth_tx_buffer_dinA,
+
+    // TX Back-End
+    output [`ETH_DATA_WR_ADDR_W-1:0]    iob_eth_tx_buffer_addrB,
+    input [32-1:0]                      iob_eth_tx_buffer_doutB,
+
+    // RX Front-End
+    output                              iob_eth_rx_buffer_enA,
+    output [32/8-1:0]                   iob_eth_rx_buffer_weA,
+    output [`ETH_DATA_RD_ADDR_W-1:0]    iob_eth_rx_buffer_addrA,
+    output [32-1:0]                     iob_eth_rx_buffer_dinA,
+
+     // RX Back-End
+    output                              iob_eth_rx_buffer_enB,
+    output [`ETH_DATA_RD_ADDR_W-1:0]    iob_eth_rx_buffer_addrB,
+    input [32-1:0]                      iob_eth_rx_buffer_doutB,

--- a/hardware/include/iob_eth_buffer_portmap.vh
+++ b/hardware/include/iob_eth_buffer_portmap.vh
@@ -1,0 +1,17 @@
+    // TX Front-End
+    .iob_eth_tx_buffer_enA(iob_eth_tx_buffer_enA),
+    .iob_eth_tx_buffer_weA(iob_eth_tx_buffer_weA),
+    .iob_eth_tx_buffer_addrA(iob_eth_tx_buffer_addrA),
+    .iob_eth_tx_buffer_dinA(iob_eth_tx_buffer_dinA),
+    // TX Back-End
+    .iob_eth_tx_buffer_addrB(iob_eth_tx_buffer_addrB),
+    .iob_eth_tx_buffer_doutB(iob_eth_tx_buffer_doutB),
+    // RX Front-End
+    .iob_eth_rx_buffer_enA(iob_eth_rx_buffer_enA),
+    .iob_eth_rx_buffer_weA(iob_eth_rx_buffer_weA),
+    .iob_eth_rx_buffer_addrA(iob_eth_rx_buffer_addrA),
+    .iob_eth_rx_buffer_dinA(iob_eth_rx_buffer_dinA),
+    // RX Back-End
+    .iob_eth_rx_buffer_enB(iob_eth_rx_buffer_enB),
+    .iob_eth_rx_buffer_addrB(iob_eth_rx_buffer_addrB),
+    .iob_eth_rx_buffer_doutB(iob_eth_rx_buffer_doutB),

--- a/hardware/include/pio.vh
+++ b/hardware/include/pio.vh
@@ -1,6 +1,25 @@
    //ETHERNET
    // External Memory Macros
-   `include "iob_eth_buffer_port.vh"
+   // TX Front-End
+   output                              iob_eth_tx_buffer_enA,
+   output [32/8-1:0]                   iob_eth_tx_buffer_weA,
+   output [`ETH_DATA_WR_ADDR_W-1:0]    iob_eth_tx_buffer_addrA,
+   output [32-1:0]                     iob_eth_tx_buffer_dinA,
+
+   // TX Back-End
+   output [`ETH_DATA_WR_ADDR_W-1:0]    iob_eth_tx_buffer_addrB,
+   input [32-1:0]                      iob_eth_tx_buffer_doutB,
+
+   // RX Front-End
+   output                              iob_eth_rx_buffer_enA,
+   output [32/8-1:0]                   iob_eth_rx_buffer_weA,
+   output [`ETH_DATA_RD_ADDR_W-1:0]    iob_eth_rx_buffer_addrA,
+   output [32-1:0]                     iob_eth_rx_buffer_dinA,
+
+    // RX Back-End
+   output                              iob_eth_rx_buffer_enB,
+   output [`ETH_DATA_RD_ADDR_W-1:0]    iob_eth_rx_buffer_addrB,
+   input [32-1:0]                      iob_eth_rx_buffer_doutB,
 
    output 		     ETH_PHY_RESETN,
    input 		     PLL_LOCKED,

--- a/hardware/include/pio.vh
+++ b/hardware/include/pio.vh
@@ -1,4 +1,7 @@
    //ETHERNET
+   // External Memory Macros
+   `include "iob_eth_buffer_port.vh"
+
    output 		     ETH_PHY_RESETN,
    input 		     PLL_LOCKED,
 

--- a/hardware/simulation/icarus/test.expected
+++ b/hardware/simulation/icarus/test.expected
@@ -1,0 +1,3 @@
+TX is ready
+RX received data
+Test successfully completed.

--- a/hardware/testbench/iob_eth_tb.v
+++ b/hardware/testbench/iob_eth_tb.v
@@ -60,6 +60,27 @@ module iob_eth_tb;
    reg [47:0] mac_addr = `ETH_MAC_ADDR;
    
    // External Memory Macros
+   // TX Front-End
+   wire                              iob_eth_tx_buffer_enA;
+   wire [32/8-1:0]                   iob_eth_tx_buffer_weA;
+   wire [`ETH_DATA_WR_ADDR_W-1:0]    iob_eth_tx_buffer_addrA;
+   wire [32-1:0]                     iob_eth_tx_buffer_dinA;
+
+   // TX Back-End
+   wire [`ETH_DATA_WR_ADDR_W-1:0]    iob_eth_tx_buffer_addrB;
+   wire [32-1:0]                      iob_eth_tx_buffer_doutB;
+
+   // RX Front-End
+   wire                              iob_eth_rx_buffer_enA;
+   wire [32/8-1:0]                   iob_eth_rx_buffer_weA;
+   wire [`ETH_DATA_RD_ADDR_W-1:0]    iob_eth_rx_buffer_addrA;
+   wire [32-1:0]                     iob_eth_rx_buffer_dinA;
+
+    // RX Back-End
+   wire                              iob_eth_rx_buffer_enB;
+   wire [`ETH_DATA_RD_ADDR_W-1:0]    iob_eth_rx_buffer_addrB;
+   wire [32-1:0]                      iob_eth_rx_buffer_doutB;
+
    `include "iob_eth_buffer_inst.vh"
    
    // Instantiate the Unit Under Test (UUT)

--- a/hardware/testbench/iob_eth_tb.v
+++ b/hardware/testbench/iob_eth_tb.v
@@ -59,12 +59,16 @@ module iob_eth_tb;
    // mac_addr
    reg [47:0] mac_addr = `ETH_MAC_ADDR;
    
+   // External Memory Macros
+   `include "iob_eth_buffer_inst.vh"
    
    // Instantiate the Unit Under Test (UUT)
 
    iob_eth uut (
       .clk        (clk),
       .rst        (rst),
+    
+      `include "iob_eth_buffer_portmap.vh"
 
       // CPU side
       .valid         (valid),


### PR DESCRIPTION
- update ethernet module to instantiate buffer memories outside core. This is a regular practice for ASIC flows