### PR TITLE
feat(doc): add remaining IOs to documentation

### DIFF
--- a/iob_eth_setup.py
+++ b/iob_eth_setup.py
@@ -63,6 +63,7 @@ confs = [
 
 ios = [
     {"name": "iob_s_port", "descr": "CPU native interface", "ports": []},
+    {"name": "axi_m_port", "descr": "AXI4 Master memory interface", "ports": []},
     {
         "name": "general",
         "descr": "General Interface Signals",
@@ -84,6 +85,12 @@ ios = [
                 "type": "I",
                 "n_bits": "1",
                 "descr": "System clock enable signal",
+            },
+            {
+                "name": "inta_o",
+                "type": "O",
+                "n_bits": "1",
+                "descr": "Interrupt Output A",
             },
         ],
     },

--- a/iob_eth_setup.py
+++ b/iob_eth_setup.py
@@ -63,7 +63,7 @@ confs = [
 
 ios = [
     {"name": "iob_s_port", "descr": "CPU native interface", "ports": []},
-    {"name": "axi_m_port", "descr": "AXI4 Master memory interface", "ports": []},
+    {"name": "iob_m_port", "descr": "Native master memory interface", "ports": []},
     {
         "name": "general",
         "descr": "General Interface Signals",


### PR DESCRIPTION
- add AXI4 Master interface. This interface replaces the wishbone master interface from the original ethmac core. 
- The wishbone slave interface is replaced by iob slave native interface that connects to CPU
- add interrupt output port