### PR TITLE
feat(phy_resetn): Add `phy_resetn_o` output port.

### DIFF
--- a/hardware/src/iob_eth.v
+++ b/hardware/src/iob_eth.v
@@ -63,22 +63,48 @@ module iob_eth # (
    assign MTxErr = 1'b0; //TODO
 
    //
+   //  PHY RESET
+   //
+
+   wire [21-1:0] phy_rst_cnt_o;
+   iob_acc #(
+      .DATA_W(21),
+      .RST_VAL(21'h100000 | (PHY_RST_CNT - 1))
+   ) phy_rst_cnt (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .rst_i(1'b0),
+      .en_i(phy_rst_cnt_o[20]),
+      .incr_i(-21'd1),
+      .data_o(phy_rst_cnt_o)
+   );
+   wire phy_rst = phy_rst_cnt_o[20];
+   assign phy_rstn_o = ~phy_rst;
+
+   //
    // SYNCHRONIZERS
    //
 
    // arst synchronizers
    wire rx_arst;
-   iob_reset_sync rx_arst_sync (
+   iob_sync #(
+      .DATA_W(1)
+   ) rx_arst_sync (
       .clk_i(MRxClk),
       .arst_i(arst_i),
-      .arst_o(rx_arst)
+      .signal_i(phy_rst),
+      .signal_o(rx_arst)
    );
 
    wire tx_arst;
-   iob_reset_sync tx_arst_sync (
+   iob_sync #(
+      .DATA_W(1)
+   ) tx_arst_sync (
       .clk_i(MTxClk),
       .arst_i(arst_i),
-      .arst_o(tx_arst)
+      .signal_i(phy_rst),
+      .signal_o(tx_arst)
    );
 
    // clk to MRxClk (f2s)

--- a/iob_eth.py
+++ b/iob_eth.py
@@ -14,6 +14,7 @@ from iob_sync import iob_sync
 from iob_f2s_1bit_sync import iob_f2s_1bit_sync
 from iob_ram_tdp_be import iob_ram_tdp_be
 from iob_ram_dp import iob_ram_dp
+from iob_acc import iob_acc
 
 
 class iob_eth(iob_module):
@@ -38,6 +39,7 @@ class iob_eth(iob_module):
                 iob_f2s_1bit_sync,
                 iob_ram_tdp_be,
                 iob_ram_dp,
+                iob_acc,
             ]
         )
 
@@ -165,7 +167,7 @@ class iob_eth(iob_module):
                     "val": "20'hFFFFF",
                     "min": "NA",
                     "max": "NA",
-                    "descr": "Reset counter value",
+                    "descr": "PHY reset counter value. Sets the duration of the PHY reset signal.",
                 },
                 {
                     "name": "BD_NUM_LOG2",
@@ -296,6 +298,12 @@ class iob_eth(iob_module):
                         "type": "O", #TODO: Make this port bidirectional. Probably best by using two separate ports, as 'inout' may not be synthesizable.
                         "n_bits": "1",
                         "descr": "Management Data Input/Output. Bi-directional serial data channel for PHY/STA communication.",
+                    },
+                    {
+                        "name": "phy_rstn_o",
+                        "type": "O",
+                        "n_bits": "1",
+                        "descr": "Reset signal for PHY.Duration configurable via PHY_RST_CNT parameter.",
                     },
                 ],
             },


### PR DESCRIPTION
Reimplement PHY reset logic inside iob-eth core.
Add `phy_resetn_o` output port for PHY reset.