### PR TITLE
feat(su): Replace `sudo` by `su root -c`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,12 +102,12 @@ doc-build: clean
 # Create a virtual network interface
 ETH_IF ?= eth10
 virtual-network-if:
-	sudo modprobe dummy
-	sudo ip link add $(ETH_IF) type dummy
-	sudo ifconfig $(ETH_IF) up
+	su root -c "modprobe dummy;\
+	ip link add $(ETH_IF) type dummy;\
+	ifconfig $(ETH_IF) up"
 
 remove-virtual-network-if:
-	sudo ip link del $(ETH_IF)
-	sudo rmmod dummy
+	su root -c "ip link del $(ETH_IF);\
+	rmmod dummy"
 
 .PHONY: virtual-network-if remove-virtual-network-if

--- a/scripts/pyRawWrapper/Makefile
+++ b/scripts/pyRawWrapper/Makefile
@@ -7,6 +7,6 @@ compile:
 
 set-capabilities:
 	@echo "Setting CAP_NET_RAW capability..."
-	sudo setcap cap_net_raw,cap_setpcap=p pyRawWrapper
+	su root -c "setcap cap_net_raw,cap_setpcap=p pyRawWrapper"
 
 .PHONY: all compile set-capabilities


### PR DESCRIPTION
Using the `su` command should make it more portable.
Some versions of NixOS do not come with `sudo` installed.