### PR TITLE
feat(Makefile): Add `fusesoc-core-file` target; Fix release-artifacts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,6 @@ fusesoc-export: clean setup
 
 .PHONY: fusesoc-export
 
-# Multiline string (use a here‑document)
 define MULTILINE_TEXT
 provider:
   name: url


### PR DESCRIPTION
Add 'fusesoc-core-file' target that allows exporting a single `<corename>.core` file with a provider URL pointing to the releases page. When FuseSoC is run for this core, it will automatically download the sources from the provider URL.
This file can be submitted to https://github.com/fusesoc/fusesoc-cores repository.

Fix release-artifacts target to avoid including the 'fusesoc_exports' as a sub-directory inside the tar.gz file.