### PR TITLE
Update VERSION retrieval method in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PY_PARAMS:=$(shell echo $(PY_PARAMS) | cut -c2-)
 endif # ifndef PY_PARAMS
 
 BUILD_DIR ?= $(shell nix-shell --run "py2hwsw $(CORE) print_build_dir --py_params '$(PY_PARAMS)'")
-VERSION ?=$(shell cat $(CORE).py | grep version | cut -d '"' -f 4)
+VERSION ?= $(shell nix-shell --run "py2hwsw $(CORE) print_core_version --py_params '$(PY_PARAMS)'")
 
 #------------------------------------------------------------
 # SETUP


### PR DESCRIPTION
This quick fix should resolve the missing version issue in the name of the .tar.gz file of the releases page.
Need to update/rerun latest release to this commit.